### PR TITLE
fix backbone version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "chaplin.js"
   ],
   "dependencies": {
-    "backbone": "1.x"
+    "backbone": "~1.1.2"
   }
 }

--- a/component.json
+++ b/component.json
@@ -7,6 +7,6 @@
     "chaplin.js"
   ],
   "dependencies": {
-    "bower_components/backbone": "1.x"
+    "bower_components/backbone": "~1.1.2"
   }
 }


### PR DESCRIPTION
Dependency shouldn't auto-update on minors, only on patches.

My app completely broke yesterday when I did a deploy because the Chaplin in bower has dependency on `1.x` and the new minor from Backbone have some breaking changes.

This is needed until https://github.com/chaplinjs/chaplin/issues/860 is resolved, then it should be changed to `~1.2.0`.
